### PR TITLE
[transitions] Do not remove cpus from configured target graph

### DIFF
--- a/rules/transition_support.bzl
+++ b/rules/transition_support.bzl
@@ -80,7 +80,13 @@ def _apple_rule_transition_impl(settings, attr):
 
     # Transition ios_multi_cpus to to a single cpu when building for iOS.
     # Rules using this transition (e.g., apple_framework_packaging, precompiled_apple_resource_bundle) don't need any artifacts from other archs.
-    ios_multi_cpus = cpu_string[4:] if platform_type == "ios" else settings["//command_line_option:ios_multi_cpus"]
+    #ios_multi_cpus = cpu_string[4:] if platform_type == "ios" else settings["//command_line_option:ios_multi_cpus"]
+
+    # NOTE(nmj): Removed the logic above, as it caused problems during the migration
+    #            from rules_pods, where those libs used every CPU provided, and
+    #            rules_ios only used one of the cpus, leading to a split configured
+    #            target graph. Just use the CPUs that we were given on the CLI.
+    ios_multi_cpus = settings["//command_line_option:ios_multi_cpus"]
 
     ret = {
         "//command_line_option:apple configuration distinguisher": "applebin_" + platform_type,


### PR DESCRIPTION
Upstream converts ios_multi_cpus to a single value. rules_pods does
not. So when rules_pods objc_library rules depend on rules_ios rules,
they are considered different configurations, and we end up splitting
the configured target graph into two configurations. When swift, objc,
etc try to link in all objc_libraries later in the build, they then
try to link the same library twice, because the configured nodes are
duplicated, and we run into duplicate symbol, module redefinition, etc
errors.

In theory, this could be reverted once the rules_ios migration is
complete, but for our use case, it should not hurt anything being
present. This logic, also, only affects our opt builds that build
for multiple cpus. The development builds are unaffected.
