### PR TITLE
[rules_ios] Re-enable cpp rules

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -1018,7 +1018,7 @@ def apple_library(name, library_tools = {}, export_private_headers = True, names
         _append_headermap_copts(swift_angle_bracket_hmap_name, "-I", additional_objc_copts, additional_swift_copts, additional_cc_copts)
 
     # Note: this line is intentionally disabled
-    if cpp_sources and False:
+    if cpp_sources:
         additional_cc_copts.append("-I.")
         native.objc_library(
             name = cpp_libname,


### PR DESCRIPTION
This was accidentally disabled. It is required for glog, so turn this
back on so that .cc/.cpp sources and their .a files are properly
propagated.

Tested by doing a build with this change off of main
