### PR TITLE
[rules_ios] Make modulemaps have '[system]', fix static_library deps

### DIFF
--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -100,13 +100,14 @@ extend_modulemap = rule(
     doc = "Extends a modulemap with a Swift submodule",
 )
 
-def _write_modulemap(name, library_tools, umbrella_header = None, public_headers = [], private_headers = [], module_name = None, framework = False, **kwargs):
+def _write_modulemap(name, library_tools, umbrella_header = None, public_headers = [], private_headers = [], module_name = None, framework = False, system_module = True, **kwargs):
     basename = "{}.modulemap".format(name)
     destination = paths.join(name + "-modulemap", basename)
+    system_module_text = "[system] " if system_module else ""
     if not module_name:
         module_name = name
     content = """\
-module {module_name} {{
+module {module_name} {system_module_text} {{
     umbrella header "{umbrella_header}"
 
     export *
@@ -115,6 +116,7 @@ module {module_name} {{
 """.format(
         module_name = module_name,
         umbrella_header = umbrella_header,
+        system_module_text = system_module_text,
     )
     if framework:
         content = "framework " + content

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -6,6 +6,7 @@ def apple_static_library(
         apple_library = apple_library,
         public_headers = [],
         public_headers_to_name = {},
+        deps = [],
         visibility = [],
         testonly = False,
         **kwargs):
@@ -107,18 +108,6 @@ def apple_static_library(
         ```
     """
 
-    public_headers = public_headers
-
-    library = apple_library(
-        name = name,
-        public_headers = public_headers,
-        visibility=visibility,
-        testonly=testonly,
-        **kwargs
-    )
-
-    platforms = library.platforms if library.platforms else {}
-
     extra_deps = []
 
     # TODO(nmj): We'll likely need to add a way to set up a private headers link tree
@@ -133,9 +122,18 @@ def apple_static_library(
         )
         extra_deps.append(public_headers_symlinks_name)
 
+    library = apple_library(
+        name = name,
+        public_headers = public_headers,
+        visibility=visibility,
+        testonly=testonly,
+        deps = deps + extra_deps,
+        **kwargs
+    )
+
     native.objc_library(
         name = name,
-        deps = library.deps + extra_deps,
+        deps = library.deps,
         data = [library.data] if library.data else [],
         linkopts = library.linkopts,
         testonly = kwargs.get("testonly", False),


### PR DESCRIPTION
- There was an ordering issue with apple_static_library where it didn't include the symlink map in the deps for the apple_library call. Make sure to route it through.
- When changing over to cocoapods bazel, we modularize a lot of things, which causes a lot of extra warnings to show up from third party packages. We're not really in charge of maintaining their code, so just add the "[system]" tag to the modulemap file. This makes the headers get included as if they were included through -isystem, not -I