### PR TITLE
[rules_ios] Expose cc_headers_symlinks, add a helper function for headers

### DIFF
--- a/rules/header_paths.bzl
+++ b/rules/header_paths.bzl
@@ -68,7 +68,7 @@ def _glob_and_strip_prefix(src_dirs, suffix = ".h"):
         ...
         # Matched from src_dir = "react/renderer/imagemanager/platform/ios/react"
         #   glob "react/renderer/imagemanager/platform/ios/react/**/*.h"
-        "react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h": "react/renderer/iamgemanager/RCTImageManager.h",
+        "react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h": "react/renderer/imagemanager/RCTImageManager.h",
         ...
     }
 

--- a/rules/header_paths.bzl
+++ b/rules/header_paths.bzl
@@ -47,9 +47,47 @@ def _mapped_without_prefix(files, prefix):
             fail("File `{}` does not start with prefix `{}`".format(file, prefix))
     return ret
 
+def _glob_and_strip_prefix(src_dirs, suffix = ".h"):
+    """
+    Takes a list of directories, and converts them to a mapping of src -> dest
+
+    For each src_dir, all files ending in `suffix`, recursively, are remapped.
+    The remapping is from the original path to the last component of `src_dir` +
+    the remainder of that file's path. The most topologically deep path gets
+    precedence in the returned dictionary.
+
+    For example, for ReactCommon,
+    `glob_and_strip_prefix(["react", "react/renderer/imagemanager/platform/ios/react"])`
+
+    might return something like:
+
+    {
+        ...
+        # Matched from src_dir = "react", glob "react/**/*.h"
+        "react/debug/flags.h": "react/debug/flags.h",
+        ...
+        # Matched from src_dir = "react/renderer/imagemanager/platform/ios/react"
+        #   glob "react/renderer/imagemanager/platform/ios/react/**/*.h"
+        "react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h": "react/renderer/iamgemanager/RCTImageManager.h",
+        ...
+    }
+
+    This is mostly useful for merging several directories of globs into a single
+    mapping for use by `cc_headers_symlinks` in `@rules_ios//:apple_static_library.bzl`
+    """
+    ret = {}
+    for src_dir in sorted(src_dirs):
+        top_level = paths.basename(src_dir)
+        prefix = paths.dirname(src_dir)
+        to_strip = len(prefix) + 1 if prefix else 0
+        for file in native.glob(["{}/**/*{}".format(src_dir, suffix)]):
+            ret[file] = file[to_strip:]
+    return ret
+
 header_paths = struct(
     stringify_mapping = _stringify_mapping,
     get_mapped_path = _get_mapped_path,
     get_string_mapped_path = _get_string_mapped_path,
     mapped_without_prefix = _mapped_without_prefix,
+    glob_and_strip_prefix = _glob_and_strip_prefix,
 )

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -116,7 +116,7 @@ def apple_static_library(
     #            that some Pods do.
     if public_headers_to_name:
         public_headers_symlinks_name = "{}_public_headers_symlinks".format(name)
-        _headers_symlinks(
+        _cc_headers_symlinks(
             name = public_headers_symlinks_name,
             hdrs = public_headers_to_name,
             system_module = system_module,
@@ -143,7 +143,7 @@ def apple_static_library(
         visibility = visibility,
     )
 
-def _headers_symlinks_impl(ctx):
+def _cc_headers_symlinks_impl(ctx):
     if not ctx.attr.hdrs:
         return []
 
@@ -177,9 +177,13 @@ def _headers_symlinks_impl(ctx):
         apple_common.new_objc_provider(),
     ]
 
-_headers_symlinks = rule(
-    implementation = _headers_symlinks_impl,
-    doc = "Rule that actually creates symlink trees for header remapping",
+cc_headers_symlinks = rule(
+    implementation = _cc_headers_symlinks_impl,
+    doc = (
+        "Rule that actually creates symlink trees for header remapping. " +
+        "Exports them with -I or -isystem and can be taken as a dep in " +
+        "rules that handle CcInfo"
+    ),
     attrs = {
         "hdrs": attr.label_keyed_string_dict(
             allow_files = True,

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -116,7 +116,7 @@ def apple_static_library(
     #            that some Pods do.
     if public_headers_to_name:
         public_headers_symlinks_name = "{}_public_headers_symlinks".format(name)
-        _cc_headers_symlinks(
+        cc_headers_symlinks(
             name = public_headers_symlinks_name,
             hdrs = public_headers_to_name,
             system_module = system_module,


### PR DESCRIPTION
Expose cc_headers_symlinks so that we can use it in a refactor of
React-Core and ReactCommon. Also expose a helper function for use by
ReactCommon
