### PR TITLE
[rules_ios] Add more entitlement errors

### DIFF
--- a/patches/build_bazel_rules_apple.patch
+++ b/patches/build_bazel_rules_apple.patch
@@ -1,0 +1,30 @@
+diff -ur a/tools/plisttool/plisttool.py b/tools/plisttool/plisttool.py
+--- a/tools/plisttool/plisttool.py	2023-08-23 00:50:38
++++ b/tools/plisttool/plisttool.py	2023-08-23 00:50:30
+@@ -294,15 +294,26 @@
+ 
+ _ENTITLEMENTS_TO_VALIDATE_WITH_PROFILE = (
+     'aps-environment',
++    'com.apple.developer.applesignin',
++    'com.apple.developer.carplay-audio',
++    'com.apple.developer.carplay-charging',
++    'com.apple.developer.carplay-maps',
++    'com.apple.developer.carplay-messaging',
++    'com.apple.developer.carplay-parking',
++    'com.apple.developer.carplay-quick-ordering',
++    'com.apple.developer.playable-content',
+     'com.apple.developer.networking.wifi-info',
+     'com.apple.developer.passkit.pass-presentation-suppression',
+     'com.apple.developer.payment-pass-provisioning',
++    'com.apple.developer.proximity-reader.payment.acceptance',
+     'com.apple.developer.siri',
+     'com.apple.developer.usernotifications.critical-alerts',
+     'com.apple.developer.usernotifications.time-sensitive',
+     # Keys which have a list of potential values in the profile, but only one in
+     # the entitlements that must be in the profile's list of values
+     'com.apple.developer.devicecheck.appattest-environment',
++    'com.apple.storekit.request-data',
++    'com.apple.developer.storekit.request-data',
+ )
+ 
+ ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH = (

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -66,6 +66,10 @@ def rules_ios_dependencies():
         project = "bazelbuild",
         repo = "rules_apple",
         sha256 = "5e82a98a591efda772a5ee96ed17bcad38338aafeba6055daab04a5d6c13ea50",
+        patches = [
+            "@build_bazel_rules_ios//:patches/build_bazel_rules_apple.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     _maybe(


### PR DESCRIPTION
If there are keys that are in the .entitlements file that are missing from the provisioning profile, this normally results in an error. However, this is a manually specified list. These storekit ones bit us recently, so add the storekit ones, and then just pull in the list from main
(https://github.com/bazelbuild/rules_apple/blob/cc1e5b17d0bf16a74c74f9fb3e2940d9c97c12da/tools/plisttool/plisttool.py#L295-L314)