### PR TITLE
[rules_apple] add upstream filesystem patches

### DIFF
--- a/patches/build_bazel_rules_apple_filesystem.patch
+++ b/patches/build_bazel_rules_apple_filesystem.patch
@@ -1,0 +1,49 @@
+diff --git a/tools/bundletool/bundletool_experimental.py b/tools/bundletool/bundletool_experimental.py
+index 78f4923e..ab6d1d19 100644
+--- a/tools/bundletool/bundletool_experimental.py
++++ b/tools/bundletool/bundletool_experimental.py
+@@ -46,21 +46,23 @@ following keys:
+       bundle is complete but before it is signed.
+ """
+ 
++import errno
+ import filecmp
+ import json
+ import os
+ import shutil
+ import sys
+ import zipfile
+-from ctypes import cdll, c_char_p, c_int
++from ctypes import CDLL, c_char_p, c_int, get_errno
+ 
+ _CLONEFILE = None
++_USE_CLONEFILE = sys.platform == "darwin"
+ def _load_clonefile():
+   global _CLONEFILE
+   if _CLONEFILE:
+     return _CLONEFILE
+ 
+-  system = cdll.LoadLibrary('/usr/lib/libSystem.dylib')
++  system = CDLL('/usr/lib/libSystem.dylib', use_errno=True)
+   _CLONEFILE = system.clonefile
+   _CLONEFILE.argtypes = [c_char_p, c_char_p, c_int] # src, dest, flags
+   _CLONEFILE.restype = c_int  # 0 on success
+@@ -212,11 +214,16 @@ class Bundler(object):
+       raise BundleConflictError(dest)
+ 
+     self._makedirs_safely(os.path.dirname(full_dest))
+-    if sys.platform == "darwin":
++    global _USE_CLONEFILE
++    if _USE_CLONEFILE:
+       clonefile = _load_clonefile()
+       result = clonefile(src.encode(), full_dest.encode(), 0)
+       if result != 0:
+-        raise Exception(f"failed to clonefile {src} to {full_dest}")
++        if get_errno() in (errno.EXDEV, errno.ENOTSUP):
++          _USE_CLONEFILE = False
++          shutil.copy(src, full_dest)
++        else:
++          raise Exception(f"failed to clonefile {src} to {full_dest}")
+     else:
+       shutil.copy(src, full_dest)
+     os.chmod(full_dest, 0o755 if executable else 0o644)

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -68,6 +68,7 @@ def rules_ios_dependencies():
         sha256 = "5e82a98a591efda772a5ee96ed17bcad38338aafeba6055daab04a5d6c13ea50",
         patches = [
             "@build_bazel_rules_ios//:patches/build_bazel_rules_apple.patch",
+            "@build_bazel_rules_ios//:patches/build_bazel_rules_apple_filesystem.patch",
         ],
         patch_args = ["-p1"],
     )


### PR DESCRIPTION
this adds [this commit](https://github.com/bazelbuild/rules_apple/commit/306e3003c3ad562bda6cd8217179e2fcc46906f6) to address this error when copying results files across filesystem boundaries.

sample failure: https://buildkite.com/discord/discord-ios/builds/53483#018c847c-dab3-409e-bbdd-447987157fd4/897-2355