### PR TITLE
[rules_apple] Add support for xcprivacy manifests in extensions

### DIFF
--- a/patches/build_bazel_rules_apple.patch
+++ b/patches/build_bazel_rules_apple.patch
@@ -1,7 +1,20 @@
-diff -ur a/tools/plisttool/plisttool.py b/tools/plisttool/plisttool.py
---- a/tools/plisttool/plisttool.py	2023-08-23 00:50:38
-+++ b/tools/plisttool/plisttool.py	2023-08-23 00:50:30
-@@ -294,15 +294,26 @@
+diff --git a/apple/internal/ios_rules.bzl b/apple/internal/ios_rules.bzl
+index 9b0d1270..73dfb375 100644
+--- a/apple/internal/ios_rules.bzl
++++ b/apple/internal/ios_rules.bzl
+@@ -927,6 +927,7 @@ def _ios_extension_impl(ctx):
+         attr = ctx.attr,
+         res_attrs = [
+             "app_icons",
++            "resources",
+             "strings",
+         ],
+     )
+diff --git a/tools/plisttool/plisttool.py b/tools/plisttool/plisttool.py
+index ecc84f28..2cd295cc 100644
+--- a/tools/plisttool/plisttool.py
++++ b/tools/plisttool/plisttool.py
+@@ -294,15 +294,26 @@ ENTITLEMENTS_VALUE_NOT_IN_LIST = (
  
  _ENTITLEMENTS_TO_VALIDATE_WITH_PROFILE = (
      'aps-environment',


### PR DESCRIPTION
Bringing a change in from upstream of rules_apple to support adding privacy manifests for our extensions https://github.com/bazelbuild/rules_apple/pull/2439/commits/e9159fa5e4e8c21e09e667a85e67c16025211a7a