### PR TITLE
[rules_ios] Rebase onto upstream 4.8.2, squash patches, and fix / cleanup custom patches

### DIFF
--- a/.github/workflows/preflight_env.sh
+++ b/.github/workflows/preflight_env.sh
@@ -8,7 +8,7 @@ set -e
 #   - XCODE_VERSION: The version of Xcode to use.
 
 # GitHub runners are hitting 'module not found pkg_resources' required by prepare_sim.py
-pip3 install setuptools --break-system-packages
+pip3 install setuptools==69.5.1 --break-system-packages
 
 # If flag --no-bzlmod is passed, writes a user.bazelrc file to disable Bzlmod.
 if [[ "$*" == *--no-bzlmod* ]]; then

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -32,6 +32,7 @@ bazel_dep(
 bazel_dep(
     name = "rules_swift",
     version = "1.18.0",
+    max_compatibility_level = 2,
     repo_name = "build_bazel_rules_swift",
 )
 bazel_dep(

--- a/rules/BUILD.bazel
+++ b/rules/BUILD.bazel
@@ -104,6 +104,7 @@ bzl_library(
     visibility = ["//visibility:public"],
     deps = [
         ":features",
+        "//rules:utils.bzl",
         "//rules/internal:objc_provider_utils",
         "@build_bazel_rules_apple//apple",
     ],

--- a/rules/framework.bzl
+++ b/rules/framework.bzl
@@ -8,9 +8,11 @@ load("//rules:providers.bzl", "AvoidDepsInfo", "FrameworkInfo")
 load("//rules:transition_support.bzl", "transition_support")
 load("//rules:utils.bzl", "is_bazel_7")
 load("//rules/internal:objc_provider_utils.bzl", "objc_provider_utils")
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("@bazel_skylib//lib:partial.bzl", "partial")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/cpp:toolchain_utils.bzl", "find_cpp_toolchain", "use_cpp_toolchain")
+load("@bazel_skylib//lib:types.bzl", "types")
 load("@build_bazel_rules_apple//apple/internal:apple_product_type.bzl", "apple_product_type")
 load("@build_bazel_rules_apple//apple/internal:features_support.bzl", "features_support")
 load("@build_bazel_rules_apple//apple/internal:linking_support.bzl", "linking_support")
@@ -31,6 +33,7 @@ load(
     "apple_resource_aspect",
 )
 load("//rules:force_load_direct_deps.bzl", "force_load_direct_deps")
+load("//rules:header_paths.bzl", "header_paths")
 
 _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "visibility",
@@ -43,6 +46,30 @@ _APPLE_FRAMEWORK_PACKAGING_KWARGS = [
     "exported_symbols_lists",
 ]
 
+_HEADER_EXTS = {
+    "srcs": (".h", ".hh", ".hpp"),
+    "public_headers": (".inc", ".h", ".hh", ".hpp"),
+    "private_headers": (".inc", ".h", ".hh", ".hpp"),
+}
+
+def _generate_headers_mapping(headers_mapping, kwargs):
+    if types.is_dict(headers_mapping):
+        return headers_mapping
+
+    to_map = []
+    for attr in headers_mapping.attrs:
+        exts = _HEADER_EXTS[attr]
+        to_map += [h for h in kwargs.get(attr, []) if h.endswith(exts)]
+
+    headers = collections.uniq(to_map)
+    if headers_mapping.op == "strip":
+        return header_paths.mapped_without_prefix(headers, headers_mapping.pattern)
+    elif headers_mapping.op == "add":
+        return {h: headers_mapping.pattern + h for h in headers}
+    else:
+        fail("Invalid headers_mapping `{}`".format(headers_mapping))
+
+
 def apple_framework(
         name,
         apple_library = apple_library,
@@ -50,6 +77,7 @@ def apple_framework(
         infoplists_by_build_setting = {},
         xcconfig = {},
         xcconfig_by_build_setting = {},
+        headers_mapping = {},
         **kwargs):
     """Builds and packages an Apple framework.
 
@@ -72,6 +100,18 @@ def apple_framework(
 
                                    If '//conditions:default' is not set the value in 'xcconfig'
                                    is set as default.
+        headers_mapping: Either a dictionary, or the value from add_prefix / strip_prefix.
+
+                         If a dictionary, a mapping of {str: str}, where the key is a
+                         path to a header, and the value where that header should be
+                         placed in Headers, PrivateHeaders, umbrella headers, hmaps, etc.
+
+                         If the result of header_paths.add_prefix, then the attributes
+                         specified will have the prefix appended to the beginning.
+
+                         If the result of header_paths.strip_prefix, then the
+                         attributes specified will have the prefix reoved from the
+                         beginning.
         **kwargs: Arguments passed to the apple_library and apple_framework_packaging rules as appropriate.
     """
     framework_packaging_kwargs = {arg: kwargs.pop(arg) for arg in _APPLE_FRAMEWORK_PACKAGING_KWARGS if arg in kwargs}
@@ -96,11 +136,14 @@ def apple_framework(
 
     testonly = kwargs.pop("testonly", False)
 
+    if headers_mapping:
+        headers_mapping = _generate_headers_mapping(headers_mapping, kwargs)
     library = apple_library(
         name = name,
         testonly = testonly,
         xcconfig = xcconfig,
         xcconfig_by_build_setting = xcconfig_by_build_setting,
+        headers_mapping = headers_mapping,
         **kwargs
     )
 
@@ -155,6 +198,7 @@ def apple_framework(
         testonly = testonly,
         minimum_os_version = minimum_os_version,
         platform_type = platform_type,
+        headers_mapping = headers_mapping,
         **framework_packaging_kwargs
     )
 
@@ -188,35 +232,39 @@ def _find_framework_dir(outputs):
         return prefix + ".framework"
     return None
 
-def _framework_packaging_symlink_headers(ctx, inputs, outputs):
-    inputs_by_basename = {input.basename: input for input in inputs}
+def _framework_packaging_symlink_headers(ctx, inputs, outputs, headers_mapping):
+    inputs_by_mapped_name = {header_paths.get_mapped_path(input, headers_mapping): input for input in inputs}
 
     # If this check is true it means that multiple inputs have the same 'basename',
     # an additional check is done to see if that was caused by 'action_inputs' containing
     # two different paths to the same file
     #
     # In that case fails with a msg listing the differences found
-    if len(inputs_by_basename) != len(inputs):
-        inputs_by_basename_paths = [x.path for x in inputs_by_basename.values()]
-        inputs_with_duplicated_basename = [x for x in inputs if not x.path in inputs_by_basename_paths]
+    if len(inputs_by_mapped_name) != len(inputs):
+        inputs_by_mapped_name_paths = [x.path for x in inputs_by_mapped_name.values()]
+        inputs_with_duplicated_basename = [x for x in inputs if not x.path in inputs_by_mapped_name_paths]
         if len(inputs_with_duplicated_basename) > 0:
+            # TODO: Fix this error message
             fail("""
                 [Error] Multiple files with the same name exists.\n
                 See below for the list of paths found for each basename:\n
                 {}
-            """.format({x.basename: (x.path, inputs_by_basename[x.basename].path) for x in inputs_with_duplicated_basename}))
+            """.format({
+                    header_paths.get_mapped_path(x, headers_mapping):
+                    (x.path, inputs_by_mapped_name[header_paths.get_mapped_path(x, headers_mapping)].path)
+                for x in inputs_with_duplicated_basename
+            }))
 
     # If no error occurs create symlinks for each output with
     # each input as 'target_file'
-    output_input_dict = {output: inputs_by_basename[output.basename] for output in outputs}
-    for (output, input) in output_input_dict.items():
+    for (input, output) in zip(inputs, outputs):
         ctx.actions.symlink(output = output, target_file = input)
 
-def _framework_packaging_single(ctx, action, inputs, output, manifest = None):
-    outputs = _framework_packaging_multi(ctx, action, inputs, [output], manifest = manifest)
+def _framework_packaging_single(ctx, action, inputs, output, manifest = None, headers_mapping = {}):
+    outputs = _framework_packaging_multi(ctx, action, inputs, [output], manifest = manifest, headers_mapping = headers_mapping)
     return outputs[0] if outputs else None
 
-def _framework_packaging_multi(ctx, action, inputs, outputs, manifest = None):
+def _framework_packaging_multi(ctx, action, inputs, outputs, manifest = None, headers_mapping = {}):
     if not inputs:
         return []
     if inputs == [None]:
@@ -240,7 +288,7 @@ def _framework_packaging_multi(ctx, action, inputs, outputs, manifest = None):
     args.add_all("--outputs", outputs)
 
     if action in ["header", "private_header"]:
-        _framework_packaging_symlink_headers(ctx, inputs, outputs)
+        _framework_packaging_symlink_headers(ctx, inputs, outputs, headers_mapping)
     else:
         ctx.actions.run(
             executable = ctx.executable._framework_packaging,
@@ -311,6 +359,7 @@ def _get_virtual_framework_info(ctx, framework_files, compilation_context_fields
 def _get_framework_files(ctx, deps):
     framework_name = ctx.attr.framework_name
     bundle_extension = ctx.attr.bundle_extension
+    headers_mapping = header_paths.stringify_mapping(ctx.attr.headers_mapping)
 
     # declare framework directory
     framework_dir = "%s/%s.%s" % (ctx.attr.name, framework_name, bundle_extension)
@@ -383,7 +432,8 @@ def _get_framework_files(ctx, deps):
         if PrivateHeadersInfo in dep:
             for hdr in dep[PrivateHeadersInfo].headers.to_list():
                 private_headers_in.append(hdr)
-                destination = paths.join(framework_dir, "PrivateHeaders", hdr.basename)
+                mapped_path = header_paths.get_mapped_path(hdr, headers_mapping)
+                destination = paths.join(framework_dir, "PrivateHeaders", mapped_path)
                 private_headers_out.append(destination)
 
         has_header = False
@@ -393,7 +443,8 @@ def _get_framework_files(ctx, deps):
                     if not hdr.is_directory and hdr.path.endswith((".h", ".hh", ".hpp")):
                         has_header = True
                         headers_in.append(hdr)
-                        destination = paths.join(framework_dir, "Headers", hdr.basename)
+                        mapped_path = header_paths.get_mapped_path(hdr, headers_mapping)
+                        destination = paths.join(framework_dir, "Headers", mapped_path)
                         headers_out.append(destination)
                     elif hdr.path.endswith(".modulemap"):
                         modulemap_in = hdr
@@ -440,19 +491,19 @@ def _get_framework_files(ctx, deps):
     # so inputs that do not depend on compilation
     # are available before those that do,
     # improving parallelism
-    binary_out = _framework_packaging_single(ctx, "binary", binaries_in, binary_out, framework_manifest)
-    headers_out = _framework_packaging_multi(ctx, "header", headers_in, headers_out, framework_manifest)
-    private_headers_out = _framework_packaging_multi(ctx, "private_header", private_headers_in, private_headers_out, framework_manifest)
+    binary_out = _framework_packaging_single(ctx, "binary", binaries_in, binary_out, framework_manifest, headers_mapping)
+    headers_out = _framework_packaging_multi(ctx, "header", headers_in, headers_out, framework_manifest, headers_mapping)
+    private_headers_out = _framework_packaging_multi(ctx, "private_header", private_headers_in, private_headers_out, framework_manifest, headers_mapping)
 
     # Instead of creating a symlink of the modulemap, we need to copy it to modulemap_out.
     # It's a hacky fix to guarantee running the clean action before compiling objc files depending on this framework in non-sandboxed mode.
     # Otherwise, stale header files under framework_root will cause compilation failure in non-sandboxed mode.
-    modulemap_out = _framework_packaging_single(ctx, "modulemap", [modulemap_in], modulemap_out, framework_manifest)
-    swiftmodule_out = _framework_packaging_single(ctx, "swiftmodule", [swiftmodule_in], swiftmodule_out, framework_manifest)
-    swiftinterface_out = _framework_packaging_single(ctx, "swiftinterface", [swiftinterface_in], swiftinterface_out, framework_manifest)
-    swiftdoc_out = _framework_packaging_single(ctx, "swiftdoc", [swiftdoc_in], swiftdoc_out, framework_manifest)
-    infoplist_out = _framework_packaging_single(ctx, "infoplist", [infoplist_in], infoplist_out, framework_manifest)
-    symbol_graph_out = _framework_packaging_single(ctx, "symbol_graph", [symbol_graph_in], symbol_graph_out, framework_manifest)
+    modulemap_out = _framework_packaging_single(ctx, "modulemap", [modulemap_in], modulemap_out, framework_manifest, headers_mapping)
+    swiftmodule_out = _framework_packaging_single(ctx, "swiftmodule", [swiftmodule_in], swiftmodule_out, framework_manifest, headers_mapping)
+    swiftinterface_out = _framework_packaging_single(ctx, "swiftinterface", [swiftinterface_in], swiftinterface_out, framework_manifest, headers_mapping)
+    swiftdoc_out = _framework_packaging_single(ctx, "swiftdoc", [swiftdoc_in], swiftdoc_out, framework_manifest, headers_mapping)
+    infoplist_out = _framework_packaging_single(ctx, "infoplist", [infoplist_in], infoplist_out, framework_manifest, headers_mapping)
+    symbol_graph_out = _framework_packaging_single(ctx, "symbol_graph", [symbol_graph_in], symbol_graph_out, framework_manifest, headers_mapping)
 
     outputs = struct(
         binary = binary_out,
@@ -1299,6 +1350,7 @@ The C++ toolchain from which linking flags and other tools needed by the Swift
 toolchain (such as `clang`) will be retrieved.
 """,
         ),
+        "headers_mapping": attr.label_keyed_string_dict(allow_files=True),
     },
     doc = "Packages compiled code into an Apple .framework package",
 )

--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -387,7 +387,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
     vfs_info = _make_vfs_info(framework_name, data)
     if merge_vfsoverlays:
         vfs_info = _merge_vfs_infos(vfs_info, merge_vfsoverlays)
-        roots = _roots_from_datas(vfs_prefix, target_triple, vfs_info.values() + [data])
+        roots = _roots_from_datas(vfs_prefix, target_triple, vfs_info.values())
     else:
         roots = _make_root(
             vfs_prefix = vfs_prefix,

--- a/rules/header_paths.bzl
+++ b/rules/header_paths.bzl
@@ -1,0 +1,127 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _stringify_mapping(headers_mapping):
+    """
+    Convert a mapping of {Target: string} to a mapping of {string:string}
+
+    - Target is a target pointing to a single source file
+    - the value in `headers_mapping` is the path within Headers/PrivateHeaders to use
+      for the file.
+    """
+    ret = {}
+    for (t, dest) in headers_mapping.items():
+        files = t.files.to_list()
+        if len(files) != 1:
+            fail("{} should be a single file".format(t))
+        f = files[0]
+        if not f.is_source:
+            fail("{} should be a single source file, not a generated file".format(f))
+        ret[f.owner.name] = dest
+    return ret
+
+def _get_mapped_path(hdr, headers_mapping):
+    """
+    Get the relative destination path for a File
+
+    This will return the value of mapping, or the basename of the file if no
+    mapping exists or if `hdr` is not a source file.
+    """
+    if hdr.is_source:
+        return headers_mapping.get(hdr.owner.name, hdr.basename)
+    else:
+        return hdr.basename
+
+def _get_string_mapped_path(hdr, headers_mapping):
+    return headers_mapping.get(hdr, paths.basename(hdr))
+
+def _mapped_without_prefix(files, prefix):
+    """
+    Convert a list of source files to a mapping of those files -> paths with
+    `prefix` removed
+    """
+    ret = {}
+    for file in files:
+        if file.startswith(prefix):
+            ret[file] = file[len(prefix):]
+        else:
+            fail("File `{}` does not start with prefix `{}`".format(file, prefix))
+    return ret
+
+def _glob_and_strip_prefix(src_dirs, suffix = ".h"):
+    """
+    Takes a list of directories, and converts them to a mapping of src -> dest
+
+    For each src_dir, all files ending in `suffix`, recursively, are remapped.
+    The remapping is from the original path to the last component of `src_dir` +
+    the remainder of that file's path. The most topologically deep path gets
+    precedence in the returned dictionary.
+
+    For example, for ReactCommon,
+    `glob_and_strip_prefix(["react", "react/renderer/imagemanager/platform/ios/react"])`
+
+    might return something like:
+
+    {
+        ...
+        # Matched from src_dir = "react", glob "react/**/*.h"
+        "react/debug/flags.h": "react/debug/flags.h",
+        ...
+        # Matched from src_dir = "react/renderer/imagemanager/platform/ios/react"
+        #   glob "react/renderer/imagemanager/platform/ios/react/**/*.h"
+        "react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h": "react/renderer/imagemanager/RCTImageManager.h",
+        ...
+    }
+
+    This is mostly useful for merging several directories of globs into a single
+    mapping for use by `cc_headers_symlinks` in `@rules_ios//:apple_static_library.bzl`
+    """
+    ret = {}
+    for src_dir in sorted(src_dirs):
+        top_level = paths.basename(src_dir)
+        prefix = paths.dirname(src_dir)
+        to_strip = len(prefix) + 1 if prefix else 0
+        for file in native.glob(["{}/**/*{}".format(src_dir, suffix)]):
+            ret[file] = file[to_strip:]
+    return ret
+
+def _strip_prefix(prefix, attrs=("srcs", "private_headers", "public_headers")):
+    """
+    When remapping headers, strip the given prefix from the destination for all headers
+    in the specified attrs.
+
+    Only supported as the headers_mapping attribute in apple_framework
+    """
+    return struct(pattern = prefix, attrs = attrs, op = "strip")
+
+def _add_prefix(prefix, attrs=("srcs", "private_headers", "public_headers")):
+    """
+    When remapping headers, add the given prefix to the destination for all headers
+    in the specified attrs.
+
+    Only supported as the headers_mapping attribute in apple_framework
+    """
+    return struct(pattern = prefix, attrs = attrs, op = "add")
+
+def _identity_mapping(attrs=("srcs", "private_headers", "public_headers")):
+    """
+    Create a mapping that ensures that paths are not changed
+
+    Normally apple_framework moves all headers to a Headers/PrivateHeaders directory,
+    and often we just to make sure the files stay put in those directories with the
+    full on-filesystem layout.
+
+    This replaces doing something like `{h: h for h in HEADERS}`
+    """
+    return struct(pattern = "", attrs = attrs, op = "strip")
+
+
+header_paths = struct(
+    stringify_mapping = _stringify_mapping,
+    get_mapped_path = _get_mapped_path,
+    get_string_mapped_path = _get_string_mapped_path,
+    mapped_without_prefix = _mapped_without_prefix,
+    glob_and_strip_prefix = _glob_and_strip_prefix,
+    add_prefix = _add_prefix,
+    strip_prefix = _strip_prefix,
+    identity_mapping = _identity_mapping,
+)

--- a/rules/hmap/hmapbuild.c
+++ b/rules/hmap/hmapbuild.c
@@ -30,7 +30,7 @@ static void debug(char *format, ...);
 
 static inline void chomp(char *s);
 static void add_entry(mapping **hashmap, char *key, char *value);
-static void add_header(mapping **hashmap, char *name_space, char *header);
+static void add_header(mapping **hashmap, char *name_space, char *header, char *dest);
 static void parse_args(mapping **hashmap, char **av, int ac);
 static void parse_param_file(mapping **hashmap, char *file);
 
@@ -110,24 +110,21 @@ static void parse_args(mapping **entries, char **av, int ac) {
     av += optind;
 
     // all remaining arguments are the actual headers
-    for (; *av; av++) {
+    for (; *av; av+=2) {
         if (**av == '@') {
             // param file
             parse_param_file(entries, *av);
             continue;
         }
-        add_header(entries, cli_args.name_space, *av);
+        if(!*(av+1)) {
+          fprintf(stderr, "ERROR: header '%s' did not have a mapping as the next argument\n", *av);
+        }
+        add_header(entries, cli_args.name_space, *av, *(av+1));
     }
 }
 
-static void add_header(mapping **hashmap, char *name_space, char *header) {
-    char *bn = strdup(basename(header));
-    if (bn == NULL) {
-        fprintf(stderr,
-                "Failed to parse '%s': could not extract basename: %s\n",
-                header, strerror(errno));
-        exit(1);
-    }
+static void add_header(mapping **hashmap, char *name_space, char *header, char* dest) {
+    char *bn = strdup(dest);
     add_entry(hashmap, bn, strdup(header));
     if (name_space) {
         char *key = NULL;

--- a/rules/import_middleman.bzl
+++ b/rules/import_middleman.bzl
@@ -269,6 +269,15 @@ def _file_collector_rule_impl(ctx):
     cc_info = None
     if is_bazel_7:
         cc_info = CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                framework_includes = depset(
+                    transitive = [
+                        dep[CcInfo].compilation_context.framework_includes
+                        for dep in ctx.attr.deps
+                        if CcInfo in dep
+                    ],
+                ),
+            ),
             linking_context = cc_common.create_linking_context(
                 linker_inputs = depset([
                     cc_common.create_linker_input(

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -995,6 +995,11 @@ def apple_library(
         generated_swift_header_name = module_name + "-Swift.h"
 
         if module_map:
+            # NOTE(nmj): Need to make sure that both the extended and the regular
+            #            modulemap are included as inputs, otherwise swiftc compilation
+            #            will fail.
+            swiftc_inputs.append(module_map)
+
             extend_modulemap(
                 name = module_map + ".extended." + name,
                 destination = "%s.extended.modulemap" % name,

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -74,6 +74,17 @@ module {module_name}.Swift {{
         arguments = [args],
     )
 
+    return [
+        DefaultInfo(
+            files = depset([ctx.outputs.destination]),
+        ),
+        CcInfo(
+            compilation_context = cc_common.create_compilation_context(
+                headers = depset([ctx.outputs.destination]),
+            ),
+        ),
+    ]
+
 extend_modulemap = rule(
     implementation = _extend_modulemap_impl,
     attrs = {
@@ -961,6 +972,7 @@ def apple_library(
                 tags = _MANUAL,
             )
             module_map = "%s.extended.modulemap" % name
+            swiftc_inputs.append(module_map)
 
     # Note: this needs to go here, in order to virtualize the extended module
     framework_vfs_overlay(
@@ -991,11 +1003,11 @@ def apple_library(
                 "@build_bazel_rules_ios//:virtualize_frameworks": framework_vfs_swift_copts,
                 "//conditions:default": framework_vfs_swift_copts if enable_framework_vfs else [],
             }) + additional_swift_copts,
-            deps = deps + private_deps + private_dep_names + lib_names + select({
+            deps = deps + private_deps + private_dep_names + lib_names,
+            swiftc_inputs = swiftc_inputs + select({
                 "@build_bazel_rules_ios//:virtualize_frameworks": [framework_vfs_overlay_name_swift],
                 "//conditions:default": [framework_vfs_overlay_name_swift] if enable_framework_vfs else [],
             }),
-            swiftc_inputs = swiftc_inputs,
             features = features + ["swift.no_generated_module_map", "swift.use_pch_output_dir"] + select({
                 "@build_bazel_rules_ios//:virtualize_frameworks": ["swift.vfsoverlay"],
                 "//conditions:default": [],

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -585,6 +585,11 @@ def apple_library(
     defines = kwargs.pop("defines", [])
     testonly = kwargs.pop("testonly", False)
     features = kwargs.pop("features", [])
+    extension_safe = kwargs.pop("extension_safe", None)
+
+    # Set extra linkopt for application extension safety
+    if extension_safe:
+        linkopts.append("-fapplication-extension")
 
     # Collect the swift_library related kwargs, these are typically only set when provided to allow
     # for wider compatibility with rule_swift versions.

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -941,8 +941,6 @@ def apple_library(
             })
 
         swiftc_inputs = other_inputs + objc_hdrs + objc_private_hdrs
-        if module_map:
-            swiftc_inputs.append(module_map)
         if swift_objc_bridging_header:
             if swift_objc_bridging_header not in objc_hdrs:
                 swiftc_inputs.append(swift_objc_bridging_header)

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -589,7 +589,9 @@ def apple_library(
 
     # Set extra linkopt for application extension safety
     if extension_safe:
-        linkopts.append("-fapplication-extension")
+        linkopts += ["-fapplication-extension"]
+        objc_copts += ["-fapplication-extension"]
+        swift_copts += ["-application-extension"]
 
     # Collect the swift_library related kwargs, these are typically only set when provided to allow
     # for wider compatibility with rule_swift versions.

--- a/rules/library.bzl
+++ b/rules/library.bzl
@@ -819,14 +819,6 @@ def apple_library(
     if vendored_deps_arm64_sim:
         deps += vendored_deps_arm64_sim
 
-    resource_bundles = library_tools["resource_bundle_generator"](
-        name = name,
-        library_tools = library_tools,
-        resource_bundles = kwargs.pop("resource_bundles", {}),
-        platforms = platforms,
-    )
-    deps += resource_bundles
-
     objc_libname = "%s_objc" % name
     swift_libname = "%s_swift" % name
     cpp_libname = "%s_cpp" % name
@@ -936,8 +928,6 @@ def apple_library(
     if swift_version:
         additional_swift_copts += ["-swift-version", swift_version]
 
-    module_data = library_tools["wrap_resources_in_filegroup"](name = name + "_wrapped_resources_filegroup", srcs = data, testonly = testonly)
-
     if has_swift_sources:
         additional_swift_copts += ["-Xcc", "-I."]
         if module_map:
@@ -987,6 +977,20 @@ def apple_library(
         deps = deps + private_deps + private_dep_names + lib_names + import_vfsoverlays,
         #enable_framework_vfs = enable_framework_vfs
     )
+
+    # Generate resource bundles
+    module_data = library_tools["wrap_resources_in_filegroup"](
+        name = name + "_wrapped_resources_filegroup",
+        srcs = data,
+        testonly = testonly,
+    )
+    resource_bundles = library_tools["resource_bundle_generator"](
+        name = name,
+        library_tools = library_tools,
+        resource_bundles = kwargs.pop("resource_bundles", {}),
+        platforms = platforms,
+    )
+    deps += resource_bundles
 
     if has_swift_sources:
         # Forward the kwargs and the swift specific kwargs to the swift_library

--- a/rules/plists.bzl
+++ b/rules/plists.bzl
@@ -110,7 +110,7 @@ def write_info_plists_if_needed(name, plists):
             write_file(
                 name = plist_name,
                 out = plist_name + ".plist",
-                content = [struct(**plist).to_json()],
+                content = [json.encode(struct(**plist))],
             )
             written_plists.append(plist_name)
         else:

--- a/rules/precompiled_apple_resource_bundle.bzl
+++ b/rules/precompiled_apple_resource_bundle.bzl
@@ -164,7 +164,7 @@ def _precompiled_apple_resource_bundle_impl(ctx):
     )
     ctx.actions.write(
         output = bundletool_instructions_file,
-        content = bundletool_instructions.to_json(),
+        content = json.encode(bundletool_instructions),
     )
     bundletool_experimental = apple_mac_toolchain_info.bundletool_experimental
 

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -174,7 +174,6 @@ def _cc_headers_symlinks_impl(ctx):
     return [
         DefaultInfo(files = output_depset),
         CcInfo(compilation_context = compilation_context),
-        apple_common.new_objc_provider(),
     ]
 
 cc_headers_symlinks = rule(

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -1,0 +1,197 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//rules:library.bzl", "apple_library")
+
+def apple_static_library(
+        name,
+        apple_library = apple_library,
+        public_headers = [],
+        public_headers_to_name = {},
+        deps = [],
+        visibility = [],
+        testonly = False,
+        system_module = True,
+        **kwargs):
+
+    """
+    A thin wrapper around `apple_library` that exposes a single target to depend on
+    and allows additionally exposing renamed headers.
+
+    public_headers_to_name is a dictionary that maps input files to their output
+    location within the link tree. This link tree then is added as a dep to the
+    final library. This allows us to effectively "move" headers and #include them
+    at whatever path we want.
+
+    Every other attribute is passed through to applie_library/objc_library as is
+    from **kwargs.
+
+    Examples:
+        In the case below, we declare "include/fmt/chorno.h" as a public header,
+        but we remap it so that '#include <fmt/chrono.h>' works.
+
+        ```
+		apple_static_library(
+			name = "Texture",
+			srcs = glob([
+				"Source/**/*.h",
+				"Source/**/*.mm",
+				"Source/TextKit/*.h",
+			]),
+			module_name = "AsyncDisplayKit",
+			platforms = {"ios": "9.0"},
+			public_headers = [
+				"Source/ASBlockTypes.h",
+				"Source/ASButtonNode+Private.h",
+				"Source/ASButtonNode+Yoga.h",
+				"Source/ASButtonNode.h",
+				"Source/ASCellNode.h",
+				"Source/ASCollectionNode+Beta.h",
+				"Source/ASCollectionNode.h",
+				"Source/ASCollections.h",
+				"Source/ASCollectionView.h",
+				"Source/ASCollectionViewLayoutFacilitatorProtocol.h",
+				"Source/ASCollectionViewProtocols.h",
+				"Source/ASConfiguration.h",
+				"Source/ASConfigurationDelegate.h",
+				"Source/ASConfigurationInternal.h",
+				"Source/ASContextTransitioning.h",
+				"Source/ASControlNode+Subclasses.h",
+				"Source/ASControlNode.h",
+				"Source/ASDisplayNode+Beta.h",
+				"Source/ASDisplayNode+Convenience.h",
+				"Source/ASDisplayNode+InterfaceState.h",
+				"Source/ASDisplayNode+LayoutSpec.h",
+				"Source/ASDisplayNode+Subclasses.h",
+				"Source/ASDisplayNode+Yoga.h",
+				...
+				"Source/Details/ASAbstractLayoutController.h",
+				"Source/Details/ASBasicImageDownloader.h",
+				"Source/Details/ASBatchContext.h",
+				...
+				"Source/Debug/AsyncDisplayKit+Tips.h",
+				"Source/TextKit/ASTextNodeTypes.h",
+				"Source/TextKit/ASTextKitComponents.h",
+			],
+			public_headers_to_name = {
+				"Source/ASBlockTypes.h": "Texture/AsyncDisplayKit/ASBlockTypes.h",
+				"Source/ASButtonNode+Private.h": "Texture/AsyncDisplayKit/ASButtonNode+Private.h",
+				"Source/ASButtonNode+Yoga.h": "Texture/AsyncDisplayKit/ASButtonNode+Yoga.h",
+				...
+				"Source/Details/ASAbstractLayoutController.h": "Texture/AsyncDisplayKit/ASAbstractLayoutController.h",
+				"Source/Details/ASBasicImageDownloader.h": "Texture/AsyncDisplayKit/ASBasicImageDownloader.h",
+				"Source/Details/ASBatchContext.h": "Texture/AsyncDisplayKit/ASBatchContext.h",
+				...
+				"Source/Debug/AsyncDisplayKit+Tips.h": "Texture/AsyncDisplayKit/AsyncDisplayKit+Tips.h",
+				"Source/TextKit/ASTextNodeTypes.h": "Texture/AsyncDisplayKit/ASTextNodeTypes.h",
+				"Source/TextKit/ASTextKitComponents.h": "Texture/AsyncDisplayKit/ASTextKitComponents.h",
+			},
+			sdk_dylibs = ["c++"],
+			sdk_frameworks = [
+				"AVFoundation",
+				"AssetsLibrary",
+				"CoreLocation",
+				"CoreMedia",
+				"MapKit",
+				"Photos",
+			],
+			visibility = ["//visibility:public"],
+			xcconfig = {
+				"CLANG_CXX_LANGUAGE_STANDARD": "c++11",
+				"CLANG_CXX_LIBRARY": "libc++",
+				"GCC_PREPROCESSOR_DEFINITIONS": [
+					"AS_USE_ASSETS_LIBRARY=1",
+					"AS_USE_MAPKIT=1",
+					"AS_USE_PHOTOS=1",
+					"AS_USE_VIDEO=1",
+				],
+			},
+			deps = ["@PINRemoteImage"],
+		)
+        ```
+    """
+
+    extra_deps = []
+
+    # TODO(nmj): We'll likely need to add a way to set up a private headers link tree
+    #            that others can include as a dependency too. This is just a thing
+    #            that some Pods do.
+    if public_headers_to_name:
+        public_headers_symlinks_name = "{}_public_headers_symlinks".format(name)
+        cc_headers_symlinks(
+            name = public_headers_symlinks_name,
+            hdrs = public_headers_to_name,
+            system_module = system_module,
+            visibility = visibility,
+        )
+        extra_deps.append(public_headers_symlinks_name)
+
+    library = apple_library(
+        name = name,
+        public_headers = public_headers,
+        visibility=visibility,
+        testonly=testonly,
+        deps = deps + extra_deps,
+        system_module = system_module,
+        **kwargs
+    )
+
+    native.objc_library(
+        name = name,
+        deps = library.deps,
+        data = [library.data] if library.data else [],
+        linkopts = library.linkopts,
+        testonly = kwargs.get("testonly", False),
+        visibility = visibility,
+    )
+
+def _cc_headers_symlinks_impl(ctx):
+    if not ctx.attr.hdrs:
+        return []
+
+    outputs = []
+    public_headers_dir = None
+    for hdr, sub_path in ctx.attr.hdrs.items():
+        output = ctx.actions.declare_file(paths.join(ctx.attr.name, sub_path))
+        outputs.append(output)
+        if public_headers_dir == None:
+            public_headers_dir = output.path[:-(len(sub_path) + 1)]
+        ctx.actions.symlink(output = output, target_file = hdr.files.to_list()[0])
+
+    output_depset = depset(outputs)
+    if ctx.attr.system_module:
+        compilation_context = cc_common.create_compilation_context(
+            headers = output_depset,
+            system_includes = depset([
+                public_headers_dir,
+            ]),
+        )
+    else:
+        compilation_context = cc_common.create_compilation_context(
+            headers = output_depset,
+            includes = depset([
+                public_headers_dir,
+            ]),
+        )
+    return [
+        DefaultInfo(files = output_depset),
+        CcInfo(compilation_context = compilation_context),
+        apple_common.new_objc_provider(),
+    ]
+
+cc_headers_symlinks = rule(
+    implementation = _cc_headers_symlinks_impl,
+    doc = (
+        "Rule that actually creates symlink trees for header remapping. " +
+        "Exports them with -I or -isystem and can be taken as a dep in " +
+        "rules that handle CcInfo"
+    ),
+    attrs = {
+        "hdrs": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "Mapping of source file paths to relative path where the file should life in the link tree"
+        ),
+        "system_module": attr.bool(
+            default = True,
+            doc = "Whether the symlink headers dir should be exported as a system_include"
+        ),
+    },
+)

--- a/rules/test/lldb/lldb_test.bzl
+++ b/rules/test/lldb/lldb_test.bzl
@@ -81,7 +81,7 @@ def _ios_breakpoint_test_wrapper(name, application, cmds, test_spec, sdk, device
     write_file(
         name = name + "_test_spec",
         out = name + ".test_spec.json",
-        content = [test_spec.to_json()],
+        content = [json.encode(test_spec)],
     )
 
     lldbinit_deps = ["@build_bazel_rules_ios//rules/test/lldb:breakpoint.py"]

--- a/tests/ios/frameworks/dynamic/b/BUILD.bazel
+++ b/tests/ios/frameworks/dynamic/b/BUILD.bazel
@@ -5,10 +5,10 @@ apple_framework(
     srcs = glob(["*.swift"]),
     bundle_id = "com.example.b",
     data = ["b_data.txt"],
+    extension_safe = True,
     infoplists = ["Info.plist"],
     link_dynamic = True,
     platforms = {"ios": "12.0"},
     visibility = ["//visibility:public"],
-    xcconfig = {"APPLICATION_EXTENSION_API_ONLY": "YES"},
     deps = ["//tests/ios/frameworks/dynamic/c"],
 )

--- a/tests/ios/frameworks/dynamic/b/lib.swift
+++ b/tests/ios/frameworks/dynamic/b/lib.swift
@@ -1,6 +1,16 @@
 import c
+import WidgetKit
 
 public struct B {
     public static func run() { C.run() }
     public static func NATURE_OF_B() { B.run() }
+
+    @available(iOS 14.0, *)
+    public static func runExtension() -> [WidgetFamily] {
+        if #available(iOSApplicationExtension 16.0, *) {
+            [.accessoryCircular]
+        } else {
+            []
+        }
+    }
 }

--- a/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
+++ b/tests/ios/xcodeproj/Test-Mixed-Dynamic-App-Project.xcodeproj/project.pbxproj
@@ -16,7 +16,6 @@
 
 /* Begin PBXFileReference section */
 		02153936701CAAE5E5530BE4 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
-		49A50B056BD5E4179AC67F43 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		4B591E98E01C3FB1BE1C7410 /* BUILD.bazel */ = {isa = PBXFileReference; path = BUILD.bazel; sourceTree = "<group>"; };
 		4E0674CDE1D42113DF39B8D1 /* aWithResourceBundles.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = aWithResourceBundles.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6CD05C1A97322FF05C07A575 /* lib.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = lib.swift; sourceTree = "<group>"; };
@@ -127,7 +126,6 @@
 			children = (
 				8BD8BAFA513836E6FFFA7A8C /* b_data.txt */,
 				4B591E98E01C3FB1BE1C7410 /* BUILD.bazel */,
-				49A50B056BD5E4179AC67F43 /* Info.plist */,
 				6CD05C1A97322FF05C07A575 /* lib.swift */,
 			);
 			path = b;
@@ -407,7 +405,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;
@@ -627,7 +624,6 @@
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks \"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/c/c\"";
 				GCC_PREPROCESSOR_DEFINITIONS = "$(inherited)";
 				HEADER_SEARCH_PATHS = "\"$BAZEL_WORKSPACE_ROOT/bazel-out/ios-sim_arm64-min12.0-applebin_ios-ios_sim_arm64-dbg-ST-008b8551197e/bin/tests/ios/frameworks/dynamic/b/b_public_hmap.hmap\" \"$BAZEL_WORKSPACE_ROOT\"";
-				INFOPLIST_FILE = ../../../tests/ios/frameworks/dynamic/b/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				MACH_O_TYPE = "$(inherited)";
 				ONLY_ACTIVE_ARCH = YES;


### PR DESCRIPTION
This does a few things:

- Squashes our existing changes since our last divergence point with main. I only did this because it was easier since we had a lot of iteration on our interim PRs that isn't strictly necessary or relevant anymore.
- Removes some patches / patching logic where we had backported functionality from rules_apple. We do not need to patch rules_apple right now.
- Rebases us onto upstream version 4.8.2 of rules_ios
- Removes apple_common.new_objc_provider in _cc_headers_symlinks_impl. In the new rules_ios, that being present causes it to attempt to infer and build a swift modulemap, which we don't need.
- Removes a change we had made to CPU configuration to support both cocoapods and podtobuild at the same time. We're back on the upstream configuration.

At the end, the major changes we have vs upstream are:

- Adding static_framework rule
- Headermap rewriting
- Changing some rules from -I to -idirafter
- Mark a few things as "system" so we don't see their errors in our builds.

The original commits were:

2e4ed21 (origin/discord, origin/HEAD, discord) [rules_apple] Add support for xcprivacy manifests in extensions (#14)
86b8d2d [rules_apple] add upstream filesystem patches (#13)
0add154 [rules_ios] Add more configurability to headers_mapping (#11)
a6c59d1 [rules_ios] Add more entitlement errors (#12)
2699bd3 [rules_ios] Expose cc_headers_symlinks, add a helper function for headers (#10)
c494ff2 [rules_ios] Add objc_public_headers (#9)
7d8db25 [rules_ios] Export as system_includes (#7)
28ed123 [rules_ios] Make modulemaps have '[system]', fix static_library deps (#6)
4340c91 [rules_ios] Allow rewriting header paths for frameworks and libraries (#5)
1fc624a [rules_ios] Use -idirafter instead of -I (#4)
01a939d [rules_ios] Re-enable cpp rules (#3)
238256a [transitions] Do not remove cpus from configured target graph (#2)
429e3f0 [rules_ios] Add static library variant to allow rewriting headers (#1)