### PR TITLE
[rules_ios] Rebase all changes from #16 onto 5.3.0

### DIFF
--- a/patches/build_bazel_rules_apple.patch
+++ b/patches/build_bazel_rules_apple.patch
@@ -1,0 +1,43 @@
+diff --git a/apple/internal/ios_rules.bzl b/apple/internal/ios_rules.bzl
+index 9b0d1270..73dfb375 100644
+--- a/apple/internal/ios_rules.bzl
++++ b/apple/internal/ios_rules.bzl
+@@ -927,6 +927,7 @@ def _ios_extension_impl(ctx):
+         attr = ctx.attr,
+         res_attrs = [
+             "app_icons",
++            "resources",
+             "strings",
+         ],
+     )
+diff --git a/tools/plisttool/plisttool.py b/tools/plisttool/plisttool.py
+index ecc84f28..2cd295cc 100644
+--- a/tools/plisttool/plisttool.py
++++ b/tools/plisttool/plisttool.py
+@@ -294,15 +294,26 @@ ENTITLEMENTS_VALUE_NOT_IN_LIST = (
+ 
+ _ENTITLEMENTS_TO_VALIDATE_WITH_PROFILE = (
+     'aps-environment',
++    'com.apple.developer.applesignin',
++    'com.apple.developer.carplay-audio',
++    'com.apple.developer.carplay-charging',
++    'com.apple.developer.carplay-maps',
++    'com.apple.developer.carplay-messaging',
++    'com.apple.developer.carplay-parking',
++    'com.apple.developer.carplay-quick-ordering',
++    'com.apple.developer.playable-content',
+     'com.apple.developer.networking.wifi-info',
+     'com.apple.developer.passkit.pass-presentation-suppression',
+     'com.apple.developer.payment-pass-provisioning',
++    'com.apple.developer.proximity-reader.payment.acceptance',
+     'com.apple.developer.siri',
+     'com.apple.developer.usernotifications.critical-alerts',
+     'com.apple.developer.usernotifications.time-sensitive',
+     # Keys which have a list of potential values in the profile, but only one in
+     # the entitlements that must be in the profile's list of values
+     'com.apple.developer.devicecheck.appattest-environment',
++    'com.apple.storekit.request-data',
++    'com.apple.developer.storekit.request-data',
+ )
+ 
+ ENTITLEMENTS_BETA_REPORTS_ACTIVE_MISMATCH = (

--- a/patches/build_bazel_rules_apple_filesystem.patch
+++ b/patches/build_bazel_rules_apple_filesystem.patch
@@ -1,0 +1,49 @@
+diff --git a/tools/bundletool/bundletool_experimental.py b/tools/bundletool/bundletool_experimental.py
+index 78f4923e..ab6d1d19 100644
+--- a/tools/bundletool/bundletool_experimental.py
++++ b/tools/bundletool/bundletool_experimental.py
+@@ -46,21 +46,23 @@ following keys:
+       bundle is complete but before it is signed.
+ """
+ 
++import errno
+ import filecmp
+ import json
+ import os
+ import shutil
+ import sys
+ import zipfile
+-from ctypes import cdll, c_char_p, c_int
++from ctypes import CDLL, c_char_p, c_int, get_errno
+ 
+ _CLONEFILE = None
++_USE_CLONEFILE = sys.platform == "darwin"
+ def _load_clonefile():
+   global _CLONEFILE
+   if _CLONEFILE:
+     return _CLONEFILE
+ 
+-  system = cdll.LoadLibrary('/usr/lib/libSystem.dylib')
++  system = CDLL('/usr/lib/libSystem.dylib', use_errno=True)
+   _CLONEFILE = system.clonefile
+   _CLONEFILE.argtypes = [c_char_p, c_char_p, c_int] # src, dest, flags
+   _CLONEFILE.restype = c_int  # 0 on success
+@@ -212,11 +214,16 @@ class Bundler(object):
+       raise BundleConflictError(dest)
+ 
+     self._makedirs_safely(os.path.dirname(full_dest))
+-    if sys.platform == "darwin":
++    global _USE_CLONEFILE
++    if _USE_CLONEFILE:
+       clonefile = _load_clonefile()
+       result = clonefile(src.encode(), full_dest.encode(), 0)
+       if result != 0:
+-        raise Exception(f"failed to clonefile {src} to {full_dest}")
++        if get_errno() in (errno.EXDEV, errno.ENOTSUP):
++          _USE_CLONEFILE = False
++          shutil.copy(src, full_dest)
++        else:
++          raise Exception(f"failed to clonefile {src} to {full_dest}")
+     else:
+       shutil.copy(src, full_dest)
+     os.chmod(full_dest, 0o755 if executable else 0o644)

--- a/rules/header_paths.bzl
+++ b/rules/header_paths.bzl
@@ -1,0 +1,127 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+
+def _stringify_mapping(headers_mapping):
+    """
+    Convert a mapping of {Target: string} to a mapping of {string:string}
+
+    - Target is a target pointing to a single source file
+    - the value in `headers_mapping` is the path within Headers/PrivateHeaders to use
+      for the file.
+    """
+    ret = {}
+    for (t, dest) in headers_mapping.items():
+        files = t.files.to_list()
+        if len(files) != 1:
+            fail("{} should be a single file".format(t))
+        f = files[0]
+        if not f.is_source:
+            fail("{} should be a single source file, not a generated file".format(f))
+        ret[f.owner.name] = dest
+    return ret
+
+def _get_mapped_path(hdr, headers_mapping):
+    """
+    Get the relative destination path for a File
+
+    This will return the value of mapping, or the basename of the file if no
+    mapping exists or if `hdr` is not a source file.
+    """
+    if hdr.is_source:
+        return headers_mapping.get(hdr.owner.name, hdr.basename)
+    else:
+        return hdr.basename
+
+def _get_string_mapped_path(hdr, headers_mapping):
+    return headers_mapping.get(hdr, paths.basename(hdr))
+
+def _mapped_without_prefix(files, prefix):
+    """
+    Convert a list of source files to a mapping of those files -> paths with
+    `prefix` removed
+    """
+    ret = {}
+    for file in files:
+        if file.startswith(prefix):
+            ret[file] = file[len(prefix):]
+        else:
+            fail("File `{}` does not start with prefix `{}`".format(file, prefix))
+    return ret
+
+def _glob_and_strip_prefix(src_dirs, suffix = ".h"):
+    """
+    Takes a list of directories, and converts them to a mapping of src -> dest
+
+    For each src_dir, all files ending in `suffix`, recursively, are remapped.
+    The remapping is from the original path to the last component of `src_dir` +
+    the remainder of that file's path. The most topologically deep path gets
+    precedence in the returned dictionary.
+
+    For example, for ReactCommon,
+    `glob_and_strip_prefix(["react", "react/renderer/imagemanager/platform/ios/react"])`
+
+    might return something like:
+
+    {
+        ...
+        # Matched from src_dir = "react", glob "react/**/*.h"
+        "react/debug/flags.h": "react/debug/flags.h",
+        ...
+        # Matched from src_dir = "react/renderer/imagemanager/platform/ios/react"
+        #   glob "react/renderer/imagemanager/platform/ios/react/**/*.h"
+        "react/renderer/imagemanager/platform/ios/react/renderer/imagemanager/RCTImageManager.h": "react/renderer/imagemanager/RCTImageManager.h",
+        ...
+    }
+
+    This is mostly useful for merging several directories of globs into a single
+    mapping for use by `cc_headers_symlinks` in `@rules_ios//:apple_static_library.bzl`
+    """
+    ret = {}
+    for src_dir in sorted(src_dirs):
+        top_level = paths.basename(src_dir)
+        prefix = paths.dirname(src_dir)
+        to_strip = len(prefix) + 1 if prefix else 0
+        for file in native.glob(["{}/**/*{}".format(src_dir, suffix)]):
+            ret[file] = file[to_strip:]
+    return ret
+
+def _strip_prefix(prefix, attrs=("srcs", "private_headers", "public_headers")):
+    """
+    When remapping headers, strip the given prefix from the destination for all headers
+    in the specified attrs.
+
+    Only supported as the headers_mapping attribute in apple_framework
+    """
+    return struct(pattern = prefix, attrs = attrs, op = "strip")
+
+def _add_prefix(prefix, attrs=("srcs", "private_headers", "public_headers")):
+    """
+    When remapping headers, add the given prefix to the destination for all headers
+    in the specified attrs.
+
+    Only supported as the headers_mapping attribute in apple_framework
+    """
+    return struct(pattern = prefix, attrs = attrs, op = "add")
+
+def _identity_mapping(attrs=("srcs", "private_headers", "public_headers")):
+    """
+    Create a mapping that ensures that paths are not changed
+
+    Normally apple_framework moves all headers to a Headers/PrivateHeaders directory,
+    and often we just to make sure the files stay put in those directories with the
+    full on-filesystem layout.
+
+    This replaces doing something like `{h: h for h in HEADERS}`
+    """
+    return struct(pattern = "", attrs = attrs, op = "strip")
+
+
+header_paths = struct(
+    stringify_mapping = _stringify_mapping,
+    get_mapped_path = _get_mapped_path,
+    get_string_mapped_path = _get_string_mapped_path,
+    mapped_without_prefix = _mapped_without_prefix,
+    glob_and_strip_prefix = _glob_and_strip_prefix,
+    add_prefix = _add_prefix,
+    strip_prefix = _strip_prefix,
+    identity_mapping = _identity_mapping,
+)

--- a/rules/hmap.bzl
+++ b/rules/hmap.bzl
@@ -17,7 +17,9 @@ def _make_hmap(actions, headermap_builder, output, namespace, hdrs_lists):
         headermap_builder: an executable pointing to @bazel_build_rules_ios//rules/hmap:hmaptool
         output: the output file that will contain the built hmap
         namespace: the prefix to be used for header imports
-        hdrs_lists: an array of enumerables containing headers to be added to the hmap
+        hdrs_lists: an array of enumerables containing a tuple of (src, dest) where
+                    src is the file to be added to the hmap, and dest is the relative
+                    path where this header should be added to the hmap
     """
 
     args = actions.args()
@@ -27,7 +29,9 @@ def _make_hmap(actions, headermap_builder, output, namespace, hdrs_lists):
     args.add("--output", output)
 
     for hdrs in hdrs_lists:
-        args.add_all(hdrs)
+        for hdr in hdrs:
+            args.add(hdr[0])
+            args.add(hdr[1])
 
     args.set_param_file_format(format = "multiline")
     args.use_param_file("@%s")
@@ -51,13 +55,21 @@ def _make_headermap_impl(ctx):
 
     :return: provider with the info for this rule
     """
-    hdrs_lists = [ctx.files.hdrs]
+    hdrs_lists = [zip(ctx.files.hdrs, ctx.attr.hdr_dests)]
 
     for provider in ctx.attr.direct_hdr_providers:
         if apple_common.Objc in provider:
-            hdrs_lists.append(getattr(provider[apple_common.Objc], "direct_headers", []))
+            extra_headers = [
+                (s, s.basename)
+                for s in getattr(provider[apple_common.Objc], "direct_headers", [])
+            ]
+            hdrs_lists.append(extra_headers)
         if CcInfo in provider:
-            hdrs_lists.append(provider[CcInfo].compilation_context.direct_headers)
+            extra_headers = [
+                (s, s.basename)
+                for s in provider[CcInfo].compilation_context.direct_headers
+            ]
+            hdrs_lists.append(extra_headers)
 
         if len(hdrs_lists) == 1:
             # means neither apple_common.Objc nor CcInfo in hdr provider target
@@ -109,6 +121,10 @@ headermap = rule(
             mandatory = True,
             allow_files = True,
             doc = "The list of headers included in the headermap",
+        ),
+        "hdr_dests": attr.string_list(
+            mandatory = True,
+            doc = "The list of relative paths for each entry in hdrs",
         ),
         "direct_hdr_providers": attr.label_list(
             mandatory = False,

--- a/rules/hmap/hmapbuild.c
+++ b/rules/hmap/hmapbuild.c
@@ -30,7 +30,7 @@ static void debug(char *format, ...);
 
 static inline void chomp(char *s);
 static void add_entry(mapping **hashmap, char *key, char *value);
-static void add_header(mapping **hashmap, char *name_space, char *header);
+static void add_header(mapping **hashmap, char *name_space, char *header, char *dest);
 static void parse_args(mapping **hashmap, char **av, int ac);
 static void parse_param_file(mapping **hashmap, char *file);
 
@@ -110,24 +110,21 @@ static void parse_args(mapping **entries, char **av, int ac) {
     av += optind;
 
     // all remaining arguments are the actual headers
-    for (; *av; av++) {
+    for (; *av; av+=2) {
         if (**av == '@') {
             // param file
             parse_param_file(entries, *av);
             continue;
         }
-        add_header(entries, cli_args.name_space, *av);
+        if(!*(av+1)) {
+          fprintf(stderr, "ERROR: header '%s' did not have a mapping as the next argument\n", *av);
+        }
+        add_header(entries, cli_args.name_space, *av, *(av+1));
     }
 }
 
-static void add_header(mapping **hashmap, char *name_space, char *header) {
-    char *bn = strdup(basename(header));
-    if (bn == NULL) {
-        fprintf(stderr,
-                "Failed to parse '%s': could not extract basename: %s\n",
-                header, strerror(errno));
-        exit(1);
-    }
+static void add_header(mapping **hashmap, char *name_space, char *header, char* dest) {
+    char *bn = strdup(dest);
     add_entry(hashmap, bn, strdup(header));
     if (name_space) {
         char *key = NULL;

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -92,8 +92,8 @@ def _rules_ios_bzlmod_dependencies():
     _maybe(
         http_archive,
         name = "build_bazel_rules_apple",
-        sha256 = "b4df908ec14868369021182ab191dbd1f40830c9b300650d5dc389e0b9266c8d",
-        url = "https://github.com/bazelbuild/rules_apple/releases/download/3.5.1/rules_apple.3.5.1.tar.gz",
+        sha256 = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        url = "https://github.com/bazelbuild/rules_apple/releases/download/3.16.1/rules_apple.3.16.1.tar.gz",
     )
     _maybe(
         http_archive,

--- a/rules/static_library.bzl
+++ b/rules/static_library.bzl
@@ -1,0 +1,196 @@
+load("@bazel_skylib//lib:paths.bzl", "paths")
+load("//rules:library.bzl", "apple_library")
+
+def apple_static_library(
+        name,
+        apple_library = apple_library,
+        public_headers = [],
+        public_headers_to_name = {},
+        deps = [],
+        visibility = [],
+        testonly = False,
+        system_module = True,
+        **kwargs):
+
+    """
+    A thin wrapper around `apple_library` that exposes a single target to depend on
+    and allows additionally exposing renamed headers.
+
+    public_headers_to_name is a dictionary that maps input files to their output
+    location within the link tree. This link tree then is added as a dep to the
+    final library. This allows us to effectively "move" headers and #include them
+    at whatever path we want.
+
+    Every other attribute is passed through to applie_library/objc_library as is
+    from **kwargs.
+
+    Examples:
+        In the case below, we declare "include/fmt/chorno.h" as a public header,
+        but we remap it so that '#include <fmt/chrono.h>' works.
+
+        ```
+		apple_static_library(
+			name = "Texture",
+			srcs = glob([
+				"Source/**/*.h",
+				"Source/**/*.mm",
+				"Source/TextKit/*.h",
+			]),
+			module_name = "AsyncDisplayKit",
+			platforms = {"ios": "9.0"},
+			public_headers = [
+				"Source/ASBlockTypes.h",
+				"Source/ASButtonNode+Private.h",
+				"Source/ASButtonNode+Yoga.h",
+				"Source/ASButtonNode.h",
+				"Source/ASCellNode.h",
+				"Source/ASCollectionNode+Beta.h",
+				"Source/ASCollectionNode.h",
+				"Source/ASCollections.h",
+				"Source/ASCollectionView.h",
+				"Source/ASCollectionViewLayoutFacilitatorProtocol.h",
+				"Source/ASCollectionViewProtocols.h",
+				"Source/ASConfiguration.h",
+				"Source/ASConfigurationDelegate.h",
+				"Source/ASConfigurationInternal.h",
+				"Source/ASContextTransitioning.h",
+				"Source/ASControlNode+Subclasses.h",
+				"Source/ASControlNode.h",
+				"Source/ASDisplayNode+Beta.h",
+				"Source/ASDisplayNode+Convenience.h",
+				"Source/ASDisplayNode+InterfaceState.h",
+				"Source/ASDisplayNode+LayoutSpec.h",
+				"Source/ASDisplayNode+Subclasses.h",
+				"Source/ASDisplayNode+Yoga.h",
+				...
+				"Source/Details/ASAbstractLayoutController.h",
+				"Source/Details/ASBasicImageDownloader.h",
+				"Source/Details/ASBatchContext.h",
+				...
+				"Source/Debug/AsyncDisplayKit+Tips.h",
+				"Source/TextKit/ASTextNodeTypes.h",
+				"Source/TextKit/ASTextKitComponents.h",
+			],
+			public_headers_to_name = {
+				"Source/ASBlockTypes.h": "Texture/AsyncDisplayKit/ASBlockTypes.h",
+				"Source/ASButtonNode+Private.h": "Texture/AsyncDisplayKit/ASButtonNode+Private.h",
+				"Source/ASButtonNode+Yoga.h": "Texture/AsyncDisplayKit/ASButtonNode+Yoga.h",
+				...
+				"Source/Details/ASAbstractLayoutController.h": "Texture/AsyncDisplayKit/ASAbstractLayoutController.h",
+				"Source/Details/ASBasicImageDownloader.h": "Texture/AsyncDisplayKit/ASBasicImageDownloader.h",
+				"Source/Details/ASBatchContext.h": "Texture/AsyncDisplayKit/ASBatchContext.h",
+				...
+				"Source/Debug/AsyncDisplayKit+Tips.h": "Texture/AsyncDisplayKit/AsyncDisplayKit+Tips.h",
+				"Source/TextKit/ASTextNodeTypes.h": "Texture/AsyncDisplayKit/ASTextNodeTypes.h",
+				"Source/TextKit/ASTextKitComponents.h": "Texture/AsyncDisplayKit/ASTextKitComponents.h",
+			},
+			sdk_dylibs = ["c++"],
+			sdk_frameworks = [
+				"AVFoundation",
+				"AssetsLibrary",
+				"CoreLocation",
+				"CoreMedia",
+				"MapKit",
+				"Photos",
+			],
+			visibility = ["//visibility:public"],
+			xcconfig = {
+				"CLANG_CXX_LANGUAGE_STANDARD": "c++11",
+				"CLANG_CXX_LIBRARY": "libc++",
+				"GCC_PREPROCESSOR_DEFINITIONS": [
+					"AS_USE_ASSETS_LIBRARY=1",
+					"AS_USE_MAPKIT=1",
+					"AS_USE_PHOTOS=1",
+					"AS_USE_VIDEO=1",
+				],
+			},
+			deps = ["@PINRemoteImage"],
+		)
+        ```
+    """
+
+    extra_deps = []
+
+    # TODO(nmj): We'll likely need to add a way to set up a private headers link tree
+    #            that others can include as a dependency too. This is just a thing
+    #            that some Pods do.
+    if public_headers_to_name:
+        public_headers_symlinks_name = "{}_public_headers_symlinks".format(name)
+        cc_headers_symlinks(
+            name = public_headers_symlinks_name,
+            hdrs = public_headers_to_name,
+            system_module = system_module,
+            visibility = visibility,
+        )
+        extra_deps.append(public_headers_symlinks_name)
+
+    library = apple_library(
+        name = name,
+        public_headers = public_headers,
+        visibility=visibility,
+        testonly=testonly,
+        deps = deps + extra_deps,
+        system_module = system_module,
+        **kwargs
+    )
+
+    native.objc_library(
+        name = name,
+        deps = library.deps,
+        data = library.data if library.data else [],
+        linkopts = library.linkopts,
+        testonly = kwargs.get("testonly", False),
+        visibility = visibility,
+    )
+
+def _cc_headers_symlinks_impl(ctx):
+    if not ctx.attr.hdrs:
+        return []
+
+    outputs = []
+    public_headers_dir = None
+    for hdr, sub_path in ctx.attr.hdrs.items():
+        output = ctx.actions.declare_file(paths.join(ctx.attr.name, sub_path))
+        outputs.append(output)
+        if public_headers_dir == None:
+            public_headers_dir = output.path[:-(len(sub_path) + 1)]
+        ctx.actions.symlink(output = output, target_file = hdr.files.to_list()[0])
+
+    output_depset = depset(outputs)
+    if ctx.attr.system_module:
+        compilation_context = cc_common.create_compilation_context(
+            headers = output_depset,
+            system_includes = depset([
+                public_headers_dir,
+            ]),
+        )
+    else:
+        compilation_context = cc_common.create_compilation_context(
+            headers = output_depset,
+            includes = depset([
+                public_headers_dir,
+            ]),
+        )
+    return [
+        DefaultInfo(files = output_depset),
+        CcInfo(compilation_context = compilation_context),
+    ]
+
+cc_headers_symlinks = rule(
+    implementation = _cc_headers_symlinks_impl,
+    doc = (
+        "Rule that actually creates symlink trees for header remapping. " +
+        "Exports them with -I or -isystem and can be taken as a dep in " +
+        "rules that handle CcInfo"
+    ),
+    attrs = {
+        "hdrs": attr.label_keyed_string_dict(
+            allow_files = True,
+            doc = "Mapping of source file paths to relative path where the file should life in the link tree"
+        ),
+        "system_module": attr.bool(
+            default = True,
+            doc = "Whether the symlink headers dir should be exported as a system_include"
+        ),
+    },
+)


### PR DESCRIPTION
Does a few things to get ready for the bazel 8 update
- Rebases to 5.3.0
- Updates the rules_apple version to get https://github.com/bazelbuild/rules_apple/pull/2552
- Fix a bug in static_library that was exposed by bazel 8 update