### PR TITLE
[rules_ios] Change to_json to json.encode()

### DIFF
--- a/rules/framework/vfs_overlay.bzl
+++ b/rules/framework/vfs_overlay.bzl
@@ -426,7 +426,7 @@ def make_vfsoverlay(ctx, hdrs, module_map, private_hdrs, has_swift, swiftmodules
             "contents": roots,
         }],
     }
-    vfsoverlay_yaml = struct(**vfsoverlay_object).to_json()
+    vfsoverlay_yaml = json.encode(vfsoverlay_object)
     ctx.actions.write(
         content = vfsoverlay_yaml,
         output = output,


### PR DESCRIPTION
This was deprecated in bazel 8, so use the new api