### PR TITLE
Backport soft failure of swiftc missing on linux

### DIFF
--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,0 +1,1 @@
+exports_files(["build_bazel_rules_swift.patch"])

--- a/patches/build_bazel_rules_swift.patch
+++ b/patches/build_bazel_rules_swift.patch
@@ -1,0 +1,42 @@
+From 3851d2ed9598d8241cdc1ebf1bdaedaea3c19d1f Mon Sep 17 00:00:00 2001
+From: Denbeigh Stevens <denbeigh.stevens@discordapp.com>
+Date: Mon, 3 Feb 2025 19:33:36 +0000
+Subject: [PATCH] Warn instead of fail when `swiftc` not found on Linux (#1433)
+
+---
+ swift/internal/swift_autoconfiguration.bzl | 15 +++++++++++++--
+ 1 file changed, 13 insertions(+), 2 deletions(-)
+
+diff --git a/swift/internal/swift_autoconfiguration.bzl b/swift/internal/swift_autoconfiguration.bzl
+index 66c89175d..ee6cdc81e 100644
+--- a/swift/internal/swift_autoconfiguration.bzl
++++ b/swift/internal/swift_autoconfiguration.bzl
+@@ -266,7 +266,18 @@ def _create_linux_toolchain(repository_ctx):
+     """
+     path_to_swiftc = repository_ctx.which("swiftc")
+     if not path_to_swiftc:
+-        fail("No 'swiftc' executable found in $PATH")
++        print("""\
++No 'swiftc' executable found in $PATH. Not auto-generating a Linux Swift \
++toolchain.
++""")  # buildifier: disable=print
++        repository_ctx.file(
++            "BUILD",
++            """\
++# No 'swiftc' executable found in $PATH. Not auto-generating a Linux Swift \
++toolchain.
++""",
++        )
++        return
+ 
+     root = path_to_swiftc.dirname.dirname
+     feature_values = _compute_feature_values(repository_ctx, path_to_swiftc)
+@@ -285,7 +296,7 @@ def _create_linux_toolchain(repository_ctx):
+ 
+     repository_ctx.file(
+         "BUILD",
+-        """
++        """\
+ load(
+     "@build_bazel_rules_swift//swift/internal:swift_toolchain.bzl",
+     "swift_toolchain",

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -88,6 +88,9 @@ def _rules_ios_bzlmod_dependencies():
         sha256 = "bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2",
         url = "https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz",
         patches = [
+            # NOTE: This backports a commit from rules_swift 2.x that permits
+            # evaluation even if swiftc is not on PATH on Linux:
+            # https://github.com/bazelbuild/rules_swift/commit/a8d7635f1ce14de720cec94b759b525f04b7797e
             "@@build_bazel_rules_ios//patches:build_bazel_rules_swift.patch",
         ],
         patch_args = ["-p1"],

--- a/rules/repositories.bzl
+++ b/rules/repositories.bzl
@@ -87,6 +87,10 @@ def _rules_ios_bzlmod_dependencies():
         name = "build_bazel_rules_swift",
         sha256 = "bb01097c7c7a1407f8ad49a1a0b1960655cf823c26ad2782d0b7d15b323838e2",
         url = "https://github.com/bazelbuild/rules_swift/releases/download/1.18.0/rules_swift.1.18.0.tar.gz",
+        patches = [
+            "@@build_bazel_rules_ios//patches:build_bazel_rules_swift.patch",
+        ],
+        patch_args = ["-p1"],
     )
 
     _maybe(


### PR DESCRIPTION
Backporting [this change](https://github.com/bazelbuild/rules_swift/commit/a8d7635f1ce14de720cec94b759b525f04b7797e) to `rules_swift` version 1.x.

Unfortunately, this was only added in Oct 2024, and `rules_ios` pins `rules_swift` to 1.18.0 (released in April 2024).

Backport this patch so we can still run `bazel query` on these targets on Linux machines without `swiftc`.